### PR TITLE
Gh862 obsolete uid generation fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@
 * Bug Fix: Fix DicomClient getting stuck when sending one request fails completely (#848)
 * Added Modality LUT Sequence and VOI LUT Sequence functionality when generating a DICOM Image.
 * Bug Fix: Logging requests with very long private tags throws exception (#846)
+* Bug Fix: turn off validation when creating CFind-, CGet- or CMove-Requests, since there are no newly generated data included, but already existing UIDs have to be added there.
 
 #### v.4.0.1 (3/13/2019)
 * change IFileReference and IByteBuffer to have offset of type long so that big files can be processed (#743)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,7 +17,7 @@
 * Bug Fix: Fix DicomClient getting stuck when sending one request fails completely (#848)
 * Added Modality LUT Sequence and VOI LUT Sequence functionality when generating a DICOM Image.
 * Bug Fix: Logging requests with very long private tags throws exception (#846)
-* Bug Fix: turn off validation when creating CFind-, CGet- or CMove-Requests, since there are no newly generated data included, but already existing UIDs have to be added there.
+* Bug Fix: turn off validation when creating CFind-, CGet- or CMove-Requests, since there are no newly generated data included, but already existing UIDs have to be added there. (#860, #842)
 
 #### v.4.0.1 (3/13/2019)
 * change IFileReference and IByteBuffer to have offset of type long so that big files can be processed (#743)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,7 @@
 * Added Modality LUT Sequence and VOI LUT Sequence functionality when generating a DICOM Image.
 * Bug Fix: Logging requests with very long private tags throws exception (#846)
 * Bug Fix: turn off validation when creating CFind-, CGet- or CMove-Requests, since there are no newly generated data included, but already existing UIDs have to be added there. (#860, #842)
+* Bug Fix: generation of DicomUID using obsolete method Generate("name") resulted in invalid UIDs. (#862)
 
 #### v.4.0.1 (3/13/2019)
 * change IFileReference and IByteBuffer to have offset of type long so that big files can be processed (#743)

--- a/Contributors.md
+++ b/Contributors.md
@@ -48,3 +48,4 @@
 * [PalminX](https://github.com/PalminX)
 * [Pieter-Jan Van Robays](https://github.com/PieterJanVR)
 * [Alexander Moerman](https://github.com/amoerie)
+* [Harald Köstinger](https://github.com/hkoestin)

--- a/DICOM/DicomUID.cs
+++ b/DICOM/DicomUID.cs
@@ -62,55 +62,23 @@ namespace Dicom
 
     public sealed partial class DicomUID : DicomParseable
     {
-        public static string RootUID { get; set; }
-
-        private string _uid;
-
-        private string _name;
-
-        private DicomUidType _type;
-
-        private bool _retired;
+        public static string RootUID { get; set; } = "1.2.826.0.1.3680043.2.1343.1";
 
         public DicomUID(string uid, string name, DicomUidType type, bool retired = false)
         {
-            _uid = uid;
-            _name = name;
-            _type = type;
-            _retired = retired;
+            UID = uid;
+            Name = name;
+            Type = type;
+            IsRetired = retired;
         }
 
-        public string UID
-        {
-            get
-            {
-                return _uid;
-            }
-        }
+        public string UID { get; private set; }
 
-        public string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public string Name { get; private set; }
 
-        public DicomUidType Type
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        public DicomUidType Type { get; private set; }
 
-        public bool IsRetired
-        {
-            get
-            {
-                return _retired;
-            }
-        }
+        public bool IsRetired { get; private set; }
 
         public static void Register(DicomUID uid)
         {
@@ -125,12 +93,8 @@ namespace Dicom
         [Obsolete("This method may return statistically non-unique UIDs and is deprecated, use the method Generate()")]
         public static DicomUID Generate(string name)
         {
-            if (string.IsNullOrEmpty(RootUID))
-            {
-                RootUID = "1.2.826.0.1.3680043.2.1343.1";
-            }
-
-            var uid = $"{RootUID}.{DateTime.UtcNow}.{DateTime.UtcNow.Ticks}";
+            var now = DateTime.UtcNow;
+            var uid = $"{RootUID}.{now.ToString("yyyyMMddHHmmss")}.{now.Ticks}";
 
             return new DicomUID(uid, name, DicomUidType.SOPInstance);
         }

--- a/DICOM/Network/DicomCFindRequest.cs
+++ b/DICOM/Network/DicomCFindRequest.cs
@@ -29,7 +29,8 @@ namespace Dicom.Network
         public DicomCFindRequest(DicomQueryRetrieveLevel level, DicomPriority priority = DicomPriority.Medium)
             : base(DicomCommandField.CFindRequest, GetAffectedSOPClassUID(level), priority)
         {
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
             Level = level;
         }
 
@@ -46,7 +47,8 @@ namespace Dicom.Network
                 throw new DicomNetworkException("Overloaded constructor does not support Affected SOP Class UID: {0}", affectedSopClassUid.Name);
             }
 
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
         }
 
         /// <summary>
@@ -161,6 +163,8 @@ namespace Dicom.Network
             string studyInstanceUid = null)
         {
             var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Study);
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            dimse.Dataset.ValidateItems = false;
             dimse.Dataset.Add(DicomTag.PatientID, patientId);
             dimse.Dataset.Add(DicomTag.PatientName, patientName);
             dimse.Dataset.Add(DicomTag.IssuerOfPatientID, string.Empty);
@@ -187,6 +191,8 @@ namespace Dicom.Network
         public static DicomCFindRequest CreateSeriesQuery(string studyInstanceUid, string modality = null)
         {
             var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Series);
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            dimse.Dataset.ValidateItems = false;
             dimse.Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             dimse.Dataset.Add(DicomTag.SeriesInstanceUID, string.Empty);
             dimse.Dataset.Add(DicomTag.SeriesNumber, string.Empty);
@@ -211,6 +217,8 @@ namespace Dicom.Network
             string modality = null)
         {
             var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Image);
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            dimse.Dataset.ValidateItems = false;
             dimse.Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             dimse.Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
             dimse.Dataset.Add(DicomTag.SOPInstanceUID, string.Empty);
@@ -272,20 +280,22 @@ namespace Dicom.Network
 
             dimse.Dataset.Add(new DicomSequence(DicomTag.ProcedureCodeSequence));
 
-            var sps = new DicomDataset();
-            sps.Add(DicomTag.ScheduledStationAETitle, stationAE);
-            sps.Add(DicomTag.ScheduledStationName, stationName);
-            sps.Add(DicomTag.ScheduledProcedureStepStartDate, scheduledDateTime);
-            sps.Add(DicomTag.ScheduledProcedureStepStartTime, scheduledDateTime);
-            sps.Add(DicomTag.Modality, modality);
-            sps.Add(DicomTag.ScheduledPerformingPhysicianName, string.Empty);
-            sps.Add(DicomTag.ScheduledProcedureStepDescription, string.Empty);
-            sps.Add(new DicomSequence(DicomTag.ScheduledProtocolCodeSequence));
-            sps.Add(DicomTag.ScheduledProcedureStepLocation, string.Empty);
-            sps.Add(DicomTag.ScheduledProcedureStepID, string.Empty);
-            sps.Add(DicomTag.RequestedContrastAgent, string.Empty);
-            sps.Add(DicomTag.PreMedication, string.Empty);
-            sps.Add(DicomTag.AnatomicalOrientationType, string.Empty);
+            var sps = new DicomDataset
+            {
+                { DicomTag.ScheduledStationAETitle, stationAE },
+                { DicomTag.ScheduledStationName, stationName },
+                { DicomTag.ScheduledProcedureStepStartDate, scheduledDateTime },
+                { DicomTag.ScheduledProcedureStepStartTime, scheduledDateTime },
+                { DicomTag.Modality, modality },
+                { DicomTag.ScheduledPerformingPhysicianName, string.Empty },
+                { DicomTag.ScheduledProcedureStepDescription, string.Empty },
+                new DicomSequence(DicomTag.ScheduledProtocolCodeSequence),
+                { DicomTag.ScheduledProcedureStepLocation, string.Empty },
+                { DicomTag.ScheduledProcedureStepID, string.Empty },
+                { DicomTag.RequestedContrastAgent, string.Empty },
+                { DicomTag.PreMedication, string.Empty },
+                { DicomTag.AnatomicalOrientationType, string.Empty }
+            };
             dimse.Dataset.Add(new DicomSequence(DicomTag.ScheduledProcedureStepSequence, sps));
 
             return dimse;

--- a/DICOM/Network/DicomCFindResponse.cs
+++ b/DICOM/Network/DicomCFindResponse.cs
@@ -77,11 +77,13 @@ namespace Dicom.Network
             if (Remaining != 0) sb.AppendFormat("\n\t\tRemaining:	{0}", Remaining);
             if (Warnings != 0) sb.AppendFormat("\n\t\tWarnings:	{0}", Warnings);
             if (Failures != 0) sb.AppendFormat("\n\t\tFailures:	{0}", Failures);
-            if (Status.State != DicomState.Pending && Status.State != DicomState.Success)
+            if (Status.State != DicomState.Pending && Status.State != DicomState.Success
+                && !string.IsNullOrEmpty(Status.ErrorComment))
             {
-                if (!string.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
+                sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
             }
             return sb.ToString();
         }
+
     }
 }

--- a/DICOM/Network/DicomCGetRequest.cs
+++ b/DICOM/Network/DicomCGetRequest.cs
@@ -35,7 +35,8 @@ namespace Dicom.Network
             DicomPriority priority = DicomPriority.Medium)
             : base(DicomCommandField.CGetRequest, DicomUID.StudyRootQueryRetrieveInformationModelGET, priority)
         {
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
             Level = DicomQueryRetrieveLevel.Study;
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
         }
@@ -58,7 +59,8 @@ namespace Dicom.Network
             DicomPriority priority = DicomPriority.Medium)
             : base(DicomCommandField.CGetRequest, DicomUID.StudyRootQueryRetrieveInformationModelGET, priority)
         {
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
             Level = DicomQueryRetrieveLevel.Series;
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
@@ -86,7 +88,8 @@ namespace Dicom.Network
             DicomPriority priority = DicomPriority.Medium)
             : base(DicomCommandField.CGetRequest, DicomUID.StudyRootQueryRetrieveInformationModelGET, priority)
         {
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
             Level = DicomQueryRetrieveLevel.Image;
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);

--- a/DICOM/Network/DicomCMoveRequest.cs
+++ b/DICOM/Network/DicomCMoveRequest.cs
@@ -32,7 +32,8 @@ namespace Dicom.Network
             : base(DicomCommandField.CMoveRequest, DicomUID.StudyRootQueryRetrieveInformationModelMOVE, priority)
         {
             DestinationAE = destinationAe;
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
             Level = DicomQueryRetrieveLevel.Study;
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
         }
@@ -52,7 +53,9 @@ namespace Dicom.Network
             : base(DicomCommandField.CMoveRequest, DicomUID.StudyRootQueryRetrieveInformationModelMOVE, priority)
         {
             DestinationAE = destinationAe;
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
+
             Level = DicomQueryRetrieveLevel.Series;
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
@@ -75,7 +78,9 @@ namespace Dicom.Network
             : base(DicomCommandField.CMoveRequest, DicomUID.StudyRootQueryRetrieveInformationModelMOVE, priority)
         {
             DestinationAE = destinationAe;
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
+
             Level = DicomQueryRetrieveLevel.Image;
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -618,7 +618,7 @@ namespace Dicom.Network
                         {
                             _dimseStream.Seek(0, SeekOrigin.Begin);
 
-                            var command = new DicomDataset();
+                            var command = new DicomDataset() { ValidateItems = false };
 
                             var reader = new DicomReader();
                             reader.IsExplicitVR = false;

--- a/Tests/Desktop/DicomUIDTest.cs
+++ b/Tests/Desktop/DicomUIDTest.cs
@@ -47,6 +47,19 @@ namespace Dicom
             Assert.True(uid.UID.Length <= 64); // Currently not checked by DicomUID.IsValid
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("TEST1")]
+        [InlineData("fo-dicom")]
+        public void Obsolete_Generate_ReturnsValidUid(string name)
+        {
+            var uid = DicomUID.Generate(name);
+
+            Assert.True(DicomUID.IsValid(uid.UID));
+            Assert.True(uid.UID.Length <= 64); // Currently not checked by DicomUID.IsValid
+        }
+
         [Fact]
         public void Generate_ReturnsDifferentUidsEachTime()
         {

--- a/Tests/Desktop/DicomValidationTest.cs
+++ b/Tests/Desktop/DicomValidationTest.cs
@@ -77,6 +77,30 @@ namespace Dicom
             Assert.Throws<DicomValidationException>(() => ds.AddOrUpdate(DicomTag.ReferencedFileID, "HUGOHUGOHUGOHUGO1"));
         }
 
+
+        [Fact]
+        public void AddInvalidUIDMultiplicity()
+        {
+            Assert.Throws<DicomValidationException>(() =>
+            {
+                var ds = new DicomDataset();
+                ds.Add(DicomTag.SeriesInstanceUID, "1.2.3\\3.4.5");
+            });
+
+            Assert.Throws<DicomValidationException>(() =>
+            {
+                var ds = new DicomDataset();
+                ds.Add(DicomTag.SeriesInstanceUID, "1.2.3", "2.3.4");
+            });
+
+            Assert.Throws<DicomValidationException>(() =>
+            {
+                var ds = new DicomDataset();
+                ds.Add(new DicomUniqueIdentifier(DicomTag.SeriesInstanceUID, "1.2.3", "3.4.5"));
+            });
+        }
+
+
         #endregion
 
     }

--- a/Tests/Desktop/Network/DicomCFindRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCFindRequestTest.cs
@@ -84,6 +84,34 @@ namespace Dicom.Network
             Assert.Null(e);
         }
 
+        [Fact]
+        public void AddSeveralUIDsToQuery()
+        {
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Series);
+                request.Dataset.Add(DicomTag.SeriesInstanceUID, "1.2.3\\3.4.5");
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+
+            e = Record.Exception(() =>
+            {
+                var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Series);
+                request.Dataset.Add(DicomTag.SeriesInstanceUID, "1.2.3", "2.3.4");
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+
+            e = Record.Exception(() =>
+            {
+                var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Series);
+                request.Dataset.Add(new DicomUniqueIdentifier(DicomTag.SeriesInstanceUID, "1.2.3", "3.4.5"));
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
         #endregion
 
         #region Support Data

--- a/Tests/Desktop/Network/DicomCFindRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCFindRequestTest.cs
@@ -31,9 +31,9 @@ namespace Dicom.Network
         public void Constructor_ParamatersAreSet()
         {
             var cfind = new DicomCFindRequest(DicomUID.UnifiedProcedureStepEventSOPClass, DicomQueryRetrieveLevel.NotApplicable, DicomPriority.High);
-            Assert.Equal(cfind.Priority, DicomPriority.High);
-            Assert.Equal(cfind.Level, DicomQueryRetrieveLevel.NotApplicable);
-            Assert.Equal(cfind.SOPClassUID, DicomUID.UnifiedProcedureStepEventSOPClass);
+            Assert.Equal(DicomPriority.High, cfind.Priority);
+            Assert.Equal(DicomQueryRetrieveLevel.NotApplicable, cfind.Level);
+            Assert.Equal(DicomUID.UnifiedProcedureStepEventSOPClass, cfind.SOPClassUID);
         }
 
         [Theory, MemberData(nameof(InstancesLevels))]
@@ -57,6 +57,31 @@ namespace Dicom.Network
             var query = new DicomCFindRequest(DicomUID.StudyRootQueryRetrieveInformationModelFIND, DicomQueryRetrieveLevel.Study);
             Assert.Equal(DicomQueryRetrieveLevel.Study, query.Level);
             Assert.Equal(DicomUID.StudyRootQueryRetrieveInformationModelFIND, query.SOPClassUID);
+        }
+
+        [Fact]
+        public void CreateQueryWithInvalidUID()
+        {
+            var invalidStudyUID = "1.2.0004";
+            var e = Record.Exception(() =>
+            {
+                var request = DicomCFindRequest.CreateSeriesQuery(invalidStudyUID);
+                Assert.Equal(invalidStudyUID, request.Dataset.GetSingleValue<string>(DicomTag.StudyInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
+        [Fact]
+        public void AddInvalidUIDToQuery()
+        {
+            var invalidStudyUID = "1.2.0004";
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Study);
+                request.Dataset.AddOrUpdate(DicomTag.StudyInstanceUID, invalidStudyUID);
+                Assert.Equal(invalidStudyUID, request.Dataset.GetSingleValue<string>(DicomTag.StudyInstanceUID));
+            });
+            Assert.Null(e);
         }
 
         #endregion

--- a/Tests/Desktop/Network/DicomCGetRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCGetRequestTest.cs
@@ -99,6 +99,31 @@ namespace Dicom.Network
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void CreateQueryWithInvalidUID()
+        {
+            var invalidStudyUID = "1.2.0004";
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCGetRequest(invalidStudyUID, DicomPriority.Medium);
+                Assert.Equal(invalidStudyUID, request.Dataset.GetSingleValue<string>(DicomTag.StudyInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
+        [Fact]
+        public void AddInvalidUIDToQuery()
+        {
+            var invalidStudyUID = "1.2.0004";
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCGetRequest(invalidStudyUID, DicomPriority.Medium);
+                request.Dataset.AddOrUpdate(DicomTag.SeriesInstanceUID, invalidStudyUID);
+                Assert.Equal(invalidStudyUID, request.Dataset.GetSingleValue<string>(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
         #endregion
 
         #region Support Data

--- a/Tests/Desktop/Network/DicomCGetRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCGetRequestTest.cs
@@ -124,6 +124,34 @@ namespace Dicom.Network
             Assert.Null(e);
         }
 
+        [Fact]
+        public void AddSeveralUIDsToQuery()
+        {
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCGetRequest("1.2.3.456");
+                request.Dataset.Add(DicomTag.SeriesInstanceUID, "1.2.3\\3.4.5");
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+
+            e = Record.Exception(() =>
+            {
+                var request = new DicomCGetRequest("1.2.3.456");
+                request.Dataset.Add(DicomTag.SeriesInstanceUID, "1.2.3", "2.3.4");
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+
+            e = Record.Exception(() =>
+            {
+                var request = new DicomCGetRequest("1.2.3.456");
+                request.Dataset.Add(new DicomUniqueIdentifier(DicomTag.SeriesInstanceUID, "1.2.3", "3.4.5"));
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
         #endregion
 
         #region Support Data

--- a/Tests/Desktop/Network/DicomCMoveRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCMoveRequestTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Microsoft Public License (MS-PL).
 
 using System.Collections.Generic;
-using System.Threading;
 
 using Xunit;
 
@@ -25,6 +24,31 @@ namespace Dicom.Network
         {
             var actual = request.Level;
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CreateQueryWithInvalidUID()
+        {
+            var invalidStudyUID = "1.2.0004";
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCMoveRequest("DestinationAE", invalidStudyUID);
+                Assert.Equal(invalidStudyUID, request.Dataset.GetSingleValue<string>(DicomTag.StudyInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
+        [Fact]
+        public void AddInvalidUIDToQuery()
+        {
+            var invalidStudyUID = "1.2.0004";
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCMoveRequest("DestinationAE", invalidStudyUID);
+                request.Dataset.AddOrUpdate(DicomTag.SeriesInstanceUID, invalidStudyUID);
+                Assert.Equal(invalidStudyUID, request.Dataset.GetSingleValue<string>(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
         }
 
         #endregion

--- a/Tests/Desktop/Network/DicomCMoveRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCMoveRequestTest.cs
@@ -51,6 +51,35 @@ namespace Dicom.Network
             Assert.Null(e);
         }
 
+
+        [Fact]
+        public void AddSeveralUIDsToQuery()
+        {
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCMoveRequest("DestinationAE", "1.2.3.456");
+                request.Dataset.Add(DicomTag.SeriesInstanceUID, "1.2.3\\3.4.5");
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+
+            e = Record.Exception(() =>
+            {
+                var request = new DicomCMoveRequest("DestinationAE", "1.2.3.456");
+                request.Dataset.Add(DicomTag.SeriesInstanceUID, "1.2.3", "2.3.4");
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+
+            e = Record.Exception(() =>
+            {
+                var request = new DicomCMoveRequest("DestinationAE", "1.2.3.456");
+                request.Dataset.Add(new DicomUniqueIdentifier(DicomTag.SeriesInstanceUID, "1.2.3", "3.4.5"));
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
         #endregion
 
         #region Support Data


### PR DESCRIPTION
Fixes #862.

#### Checklist
- [ ] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- obsolete DicomUID.Generate("name") method generated invalid UIDs.
-
-
